### PR TITLE
Fix missing import for torch in test.py

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -1,4 +1,5 @@
 # This is an exact copy of tools/test.py from open-mmlab/mmdetection3d.
+import torch # FIX: import missing
 import argparse
 import os
 import os.path as osp


### PR DESCRIPTION
Hi!
While running inference with `tools/test.py`, I encountered a `NameError: name 'torch' is not defined` around line 123. It seems the `import torch` statement was missing when applying the spconv checkpoint fix in-memory.

This PR simply adds the missing import at the top of the file to resolve the crash and allow the script to run smoothly.
