### PR TITLE
Add import for torch in test.py

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -2,7 +2,7 @@
 import argparse
 import os
 import os.path as osp
-
+import torch
 from mmengine.config import Config, ConfigDict, DictAction
 from mmengine.registry import RUNNERS
 from mmengine.runner import Runner


### PR DESCRIPTION
```
CUDA_VISIBLE_DEVICES=0 python tools/test.py configs/oneformer3d_qs_radius16_qp300_2many.py work_dirs/clean_forestformer/epoch_3000_fix.pth
/opt/conda/lib/python3.10/site-packages/mmdet3d/evaluation/functional/kitti_utils/eval.py:10: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
  def get_thresholds(scores: np.ndarray, num_gt, num_sample_pts=41):
Applying spconv checkpoint fix in-memory...
Traceback (most recent call last):
  File "/workspace/ForestFormer3D/tools/test.py", line 175, in <module>
    main()
  File "/workspace/ForestFormer3D/tools/test.py", line 123, in main
    checkpoint = torch.load(args.checkpoint, map_location='cpu')
NameError: name 'torch' is not defined
```